### PR TITLE
Altered naming scheme of metrics.

### DIFF
--- a/etc/osprofiler/osprofiler.conf.example
+++ b/etc/osprofiler/osprofiler.conf.example
@@ -2,7 +2,8 @@
 
 agents:
   - plugin: osprofiler.plugins.mysql.Mysql
-    name: "mysqlagent1"
+    name: "mysql"
+    prefix: somecloud
     metrics:
       - num_connections
     auth:
@@ -11,7 +12,8 @@ agents:
     sample_interval: 2
 
   - plugin: osprofiler.plugins.rabbit.Rabbit
-    name: "rabbitagent1"
+    name: "rabbit"
+    prefix: somecloud
     metrics:
       - num_requests
       - num_connections
@@ -21,7 +23,8 @@ agents:
     sample_interval: 2
 
   - plugin: osprofiler.plugins.system.System
-    name: "systemagent1"
+    name: "system"
+    prefix: somecloud
     metrics:
       - network
       - cpu
@@ -32,6 +35,10 @@ agents:
 
     # Name of the process agent
     name: "process"
+
+    # Optional prefix. Defaults to ''
+    # Metric names will be reported as '{prefix}.{hostname}.{restofmetric}
+    prefix: somecloud
 
     # Optionally include a list of process filters.
     # All processes will be returned without filters
@@ -57,6 +64,3 @@ backend:
       user: "root"
       password: "password"
       auth_url: "10.245.1.4"
-    
-
-

--- a/osprofiler/handlers/blueflood.py
+++ b/osprofiler/handlers/blueflood.py
@@ -1,12 +1,12 @@
 import eventlet
 eventlet.monkey_patch()
 import logging
-from handler import Handler
-from handler import Worker
 import time
-import utils
 
 from bluefloodclient.client import Blueflood
+
+from osprofiler import utils
+from handler import Handler, Worker
 
 logger = logging.getLogger('osprofiler.%s' % __name__)
 
@@ -28,7 +28,7 @@ class BluefloodHandler(Handler):
             for k, v in d.iteritems():
                 entry = {
                     "ttlInSeconds": 86400, "collectionTime": ms,
-                    "metricName": "%s.%s" % (self.host_id, k),
+                    "metricName": k,
                     "metricValue": v
                 }
                 self.queue.put(entry)

--- a/osprofiler/handlers/handler.py
+++ b/osprofiler/handlers/handler.py
@@ -1,5 +1,5 @@
 import logging
-import utils
+from osprofiler import utils
 
 logger = logging.getLogger('osprofiler.%s' % __name__)
 

--- a/osprofiler/plugins/pluginbase.py
+++ b/osprofiler/plugins/pluginbase.py
@@ -2,9 +2,8 @@ import eventlet
 eventlet.monkey_patch()
 
 import logging
+import socket
 import time
-
-from osprofiler import utils
 
 logger = logging.getLogger('osprofiler.%s' % __name__)
 
@@ -22,7 +21,23 @@ class PluginBase(object):
     def __init__(self, **kwargs):
         self.config = kwargs.get('config', {})
         self.handlers = kwargs.get('handlers', [])
-        self.host_id = utils.host_identifier()
+        self.host_id = socket.gethostname()
+
+    def metric_name(self, suffix):
+        """
+        Returns metric name of the format:
+            "{prefix - optional}.{host_id}.{name}.{suffix}"
+
+        @param suffix - String
+        @returns - String
+
+        """
+        prefix = self.config.get('prefix', '')
+        agent_name = self.config.get('name', 'agent')
+        metric_name = ".".join([self.host_id, agent_name, suffix])
+        if prefix:
+            metric_name = ".".join([prefix, metric_name])
+        return metric_name
 
     def get_sample(self):
         raise PluginException("Method get_sample not implemented.")

--- a/osprofiler/plugins/process.py
+++ b/osprofiler/plugins/process.py
@@ -16,7 +16,7 @@ class Process(pluginbase.PluginBase):
     def __init__(self, **kwargs):
         super(Process, self).__init__(**kwargs)
 
-    def _stat_key(self, suffix, process):
+    def metric_name(self, suffix, process):
         """
         Creates a dictionary key for a process with a suffix.
         Will be in the format: {process_name}.{pid}.{suffix}
@@ -26,30 +26,33 @@ class Process(pluginbase.PluginBase):
         @returns - String
 
         """
-        return "{process_name}.{pid}.{suffix}".format(
+        suffix = "{process_name}.{pid}.{suffix}".format(
             process_name=process.name(),
             pid=process.pid,
             suffix=suffix
         )
+        return super(Process, self).metric_name(suffix)
 
     def _get_memory_stats(self, process):
         memory_info = process.memory_info()
         memory_info_ex = process.memory_info_ex()
         percent = process.memory_percent()
         return {
-            self._stat_key('memory_info.rss', process): memory_info.rss,
-            self._stat_key('memory_info.vms', process): memory_info.vms,
-            self._stat_key('memory_percent', process): percent,
-            self._stat_key('memory_info_ex.rss', process): memory_info_ex.rss,
-            self._stat_key('memory_info_ex.vms', process): memory_info_ex.vms
+            self.metric_name('memory_info.rss', process): memory_info.rss,
+            self.metric_name('memory_info.vms', process): memory_info.vms,
+            self.metric_name('memory_percent', process): percent,
+            self.metric_name('memory_info_ex.rss',
+                             process): memory_info_ex.rss,
+            self.metric_name('memory_info_ex.vms',
+                             process): memory_info_ex.vms
         }
 
     def _get_cpu_stats(self, process):
         cpu_times = process.cpu_times()
         return {
-            self._stat_key('cpu_percent', process): process.cpu_percent(),
-            self._stat_key('cpu_times.user', process): cpu_times.user,
-            self._stat_key('cpu_times.system', process): cpu_times.system
+            self.metric_name('cpu_percent', process): process.cpu_percent(),
+            self.metric_name('cpu_times.user', process): cpu_times.user,
+            self.metric_name('cpu_times.system', process): cpu_times.system
         }
 
     def _should_get_metric(self, metric):

--- a/osprofiler/plugins/system.py
+++ b/osprofiler/plugins/system.py
@@ -19,34 +19,32 @@ class System(pluginbase.PluginBase):
         active_conns = [conn for conn in psutil.net_connections()
                         if conn.status == "ESTABLISHED"]
         network = {}
-        network['system.net_connections.active'] = len(active_conns)
+        network[self.metric_name('net_connections.active')] = len(active_conns)
         for key, value in psutil.net_io_counters().__dict__.items():
-            network["system.net_io_counters.%s" % key] = value
+            network[self.metric_name("net_io_counters.%s" % key)] = value
         return network
 
     def get_cpu_stats(self):
         cpu = {}
         for key, value in psutil.cpu_times_percent().__dict__.items():
-            cpu["system.cpu_times.percent.%s" % key] = value
-        cpu["system.cpu.percent"] = psutil.cpu_percent()
+            cpu[self.metric_name("cpu_times.percent.%s" % key)] = value
+        cpu[self.metric_name("cpu.percent")] = psutil.cpu_percent()
         return cpu
 
     def get_memory_stats(self):
         memory = {}
         for key, value in psutil.virtual_memory().__dict__.items():
-            memory["system.virtual_memory.%s" % key] = value
+            memory[self.metric_name("virtual_memory.%s" % key)] = value
         for key, value in psutil.swap_memory().__dict__.items():
-            memory["system.swap_memory.%s" % key] = value
+            memory[self.metric_name("swap_memory.%s" % key)] = value
         return memory
 
     def get_disk_stats(self):
         disk = {}
         for key, value in psutil.disk_usage("/").__dict__.items():
-            disk["system.disk_usage.%s" % key] = value
+            disk[self.metric_name("disk_usage./.%s" % key)] = value
         for key, value in psutil.disk_io_counters().__dict__.items():
-            disk["system.disk_io_counters.%s" % key] = value
-        # for key, value in psutil.disk_partitions().__dict__.items():
-        #    disk["system.disk_usage.%s" % key] = value
+            disk[self.metric_name("disk_io_counters.%s" % key)] = value
         return disk
 
     def get_sample(self):
@@ -64,5 +62,4 @@ class System(pluginbase.PluginBase):
         mydict.update(cpu)
         mydict.update(disk)
         sample['metrics'].append(mydict)
-        logger.info(sample)
         return sample

--- a/tests/handlers/base.py
+++ b/tests/handlers/base.py
@@ -1,0 +1,3 @@
+import logging
+logger = logging.getLogger()
+logger = logger.addHandler(logging.NullHandler())

--- a/tests/handlers/test_blueflood.py
+++ b/tests/handlers/test_blueflood.py
@@ -1,0 +1,62 @@
+import eventlet
+import mock
+import unittest
+
+from bluefloodclient.client import Blueflood
+
+import base
+
+from osprofiler.handlers import blueflood
+
+
+def side_effect_data(data):
+    return data
+
+
+class TestBluefloodHandler(unittest.TestCase):
+    """
+    Tests for the blueflood handler
+
+    """
+    mock_config = {
+        'auth': {
+            'auth_url': 'nonsense',
+            'apikey': 'nonsense',
+            'username': 'nonsense'
+        }
+    }
+
+    @mock.patch('osprofiler.handlers.blueflood.Blueflood')
+    def test_handle_data_simple(self, *mocked):
+        handler = blueflood.BluefloodHandler(config=self.mock_config)
+        handler.queue.put = mock.Mock(side_effect=side_effect_data)
+        expected = {
+            'sample.metric.1': 1,
+            'sample.metric.2': 2,
+            'sample.metric.3': 3,
+            'sample.metric.4': 4
+        }
+        sample = {
+            'metrics': [
+                {
+                    'sample.metric.1': 1,
+                    'sample.metric.2': 2
+                },
+                {
+                    'sample.metric.3': 3
+                },
+                {
+                    'sample.metric.4': 4
+                }
+            ]
+        }
+        handler.handle(sample)
+        for call in handler.queue.put.call_args_list:
+            metric_dict = call[0][0]
+            name = metric_dict['metricName']
+            value = metric_dict['metricValue']
+            self.assertTrue('ttlInSeconds' in metric_dict)
+            self.assertTrue('collectionTime' in metric_dict)
+            self.assertTrue('metricName' in metric_dict)
+            self.assertTrue(name in expected)
+            self.assertEquals(value, expected[name])

--- a/tests/plugins/test_mysql.py
+++ b/tests/plugins/test_mysql.py
@@ -1,0 +1,45 @@
+import mock
+import socket
+import unittest
+
+import base
+from osprofiler.plugins.mysql import Mysql
+
+
+class TestMysqlProcess(unittest.TestCase):
+    """
+    Tests for the mysql plugin
+
+    """
+    sample_output = "\n".join([
+        "Variable_name\tValue",
+        "Queries\t1",
+        "Threads_cached\t2",
+        "Threads_connected\t3",
+        "Threads_created\t4",
+        "Threads_running\t5"
+    ])
+
+    @mock.patch('socket.gethostname', return_value='testhost')
+    def test_metric_names(self, mocked_function):
+        """
+        Tests that correct metric names are generated.
+
+        """
+        plugin = Mysql(config={'name': 'mysql'})
+        mock_check = mock.Mock(return_value=(0, self.sample_output, ""))
+        plugin.galera_status_check = mock_check
+
+        sample = plugin.get_sample()
+
+        expected = {
+            'testhost.mysql.Queries': 1,
+            'testhost.mysql.Threads_cached': 2,
+            'testhost.mysql.Threads_connected': 3,
+            'testhost.mysql.Threads_created': 4,
+            'testhost.mysql.Threads_running': 5,
+        }
+        for metric_dict in sample.get('metrics', []):
+            for key, value in metric_dict.iteritems():
+                self.assertTrue(key in expected)
+                self.assertEquals(value, expected[key])

--- a/tests/plugins/test_pluginbase.py
+++ b/tests/plugins/test_pluginbase.py
@@ -1,5 +1,6 @@
-import unittest
 import mock
+import socket
+import unittest
 
 import base
 from osprofiler.plugins.pluginbase import PluginBase, PluginException
@@ -72,3 +73,25 @@ class TestPluginBase(unittest.TestCase):
         self.assertRaises(TestException, plugin.execute)
         assert plugin.get_sample.called
         handler.handle.assert_called_with(10)
+
+    @mock.patch('socket.gethostname', return_value='testhost')
+    def test_metric_name(self, mocked_function):
+        """
+        Tests metric name method with default prefix and non default
+
+        """
+        # Test defaults - No prefix and name should default to 'agent'
+        plugin = PluginBase()
+        expected = "testhost.agent.suffix"
+        name = plugin.metric_name('suffix')
+        self.assertEquals(name, expected)
+
+        # Test prefix - no name
+        plugin = PluginBase(config={'prefix': 'prefix'})
+        expected = "prefix.testhost.agent.suffix"
+        self.assertEquals(plugin.metric_name('suffix'), expected)
+
+        # Test name - no prefix
+        plugin = PluginBase(config={'name': 'testagent'})
+        expected = "testhost.testagent.suffix"
+        self.assertEquals(plugin.metric_name('suffix'), expected)

--- a/tests/plugins/test_process.py
+++ b/tests/plugins/test_process.py
@@ -1,4 +1,5 @@
 import mock
+import socket
 import unittest
 
 import base
@@ -58,39 +59,41 @@ class TestPluginProcess(unittest.TestCase):
     Tests for the process plugin
 
     """
-    def test_memory_stats(self):
+    @mock.patch('socket.gethostname', return_value='testhost')
+    def test_memory_stats(self, mocked_function):
         """
         Test memory stats
 
         """
-        plugin = Process()
+        plugin = Process(config={'name': 'process'})
         fake_process = FakeProcess('test')
         memory_stats = plugin._get_memory_stats(fake_process)
         self.assertTrue(isinstance(memory_stats, dict))
         expected = {
-            'test.1.memory_percent': 1,
-            'test.1.memory_info.rss': 2,
-            'test.1.memory_info.vms': 3,
-            'test.1.memory_info_ex.rss': 4,
-            'test.1.memory_info_ex.vms': 5
+            'testhost.process.test.1.memory_percent': 1,
+            'testhost.process.test.1.memory_info.rss': 2,
+            'testhost.process.test.1.memory_info.vms': 3,
+            'testhost.process.test.1.memory_info_ex.rss': 4,
+            'testhost.process.test.1.memory_info_ex.vms': 5
         }
         for key, value in expected.iteritems():
             self.assertTrue(key in memory_stats)
             self.assertEquals(memory_stats[key], value)
 
-    def test_cpu_stats(self):
+    @mock.patch('socket.gethostname', return_value='testhost')
+    def test_cpu_stats(self, mocked_function):
         """
         Test CPU stats
 
         """
-        plugin = Process()
+        plugin = Process(config={'name': 'process'})
         fake_process = FakeProcess('test')
         cpu_stats = plugin._get_cpu_stats(fake_process)
         self.assertTrue(isinstance(cpu_stats, dict))
         expected = {
-            'test.1.cpu_percent': 11,
-            'test.1.cpu_times.user': 12,
-            'test.1.cpu_times.system': 13
+            'testhost.process.test.1.cpu_percent': 11,
+            'testhost.process.test.1.cpu_times.user': 12,
+            'testhost.process.test.1.cpu_times.system': 13
         }
         for key, value in expected.iteritems():
             self.assertTrue(key in cpu_stats)

--- a/tests/plugins/test_system.py
+++ b/tests/plugins/test_system.py
@@ -1,0 +1,217 @@
+import mock
+import socket
+import unittest
+
+from collections import OrderedDict
+
+import base
+from osprofiler.plugins.system import System, psutil
+
+
+class FakeConnection():
+    def __init__(self, established=True):
+        if established:
+            self.status = 'ESTABLISHED'
+        else:
+            self.status = 'nonsense'
+
+
+def fake_net_connections():
+    for i in xrange(5):
+        yield FakeConnection(established=True)
+    for i in xrange(10):
+        yield FakeConnection(established=False)
+
+
+def fake_net_io_counters():
+    class FakeCounters(object):
+        def __init__(self):
+            self.__dict__ = OrderedDict([
+                ('bytes_sent', 1),
+                ('bytes_recv', 2),
+                ('packets_sent', 3),
+                ('packets_recv', 4),
+                ('errin', 5),
+                ('errout', 6),
+                ('dropin', 7),
+                ('dropout', 8)
+            ])
+    return FakeCounters()
+
+
+def fake_cpu_times_percent():
+    class FakePercents():
+        def __init__(self):
+            self.__dict__ = OrderedDict([
+                ('user', 1),
+                ('nice', 2),
+                ('system', 3),
+                ('idle', 4),
+                ('iowait', 5),
+                ('irq', 6),
+                ('softirq', 7),
+                ('steal', 8),
+                ('guest', 9),
+                ('guest_nice', 10)
+            ])
+    return FakePercents()
+
+
+def fake_virtual_memory():
+    class FakeMemory():
+        def __init__(self):
+            self.__dict__ = OrderedDict([
+                ('total', 1),
+                ('available', 2),
+                ('percent', 3),
+                ('used', 4),
+                ('free', 5),
+                ('active', 6),
+                ('inactive', 7),
+                ('buffers', 8),
+                ('cached', 9)
+            ])
+    return FakeMemory()
+
+
+def fake_swap_memory():
+    class FakeMemory():
+        def __init__(self):
+            self.__dict__ = OrderedDict([
+                ('total', 1),
+                ('used', 2),
+                ('free', 3),
+                ('percent', 4),
+                ('sin', 5),
+                ('sout', 6)
+            ])
+    return FakeMemory()
+
+
+def fake_disk_usage(disk):
+    class FakeUsage():
+        def __init__(self):
+            self.__dict__ = OrderedDict([
+                ('total', 1),
+                ('used', 2),
+                ('free', 3),
+                ('percent', 4)
+            ])
+    return FakeUsage()
+
+
+def fake_disk_counters():
+    class FakeCounters():
+        def __init__(self):
+            self.__dict__ = OrderedDict([
+                ('read_count', 1),
+                ('write_count', 2),
+                ('read_bytes', 3),
+                ('write_bytes', 4),
+                ('read_time', 5),
+                ('write_time', 6)
+            ])
+    return FakeCounters()
+
+
+class TestPluginSystem(unittest.TestCase):
+    """
+    Tests for the system plugin
+
+    """
+    @mock.patch('socket.gethostname', return_value='testhost')
+    @mock.patch('psutil.net_connections', side_effect=fake_net_connections)
+    @mock.patch('psutil.net_io_counters', side_effect=fake_net_io_counters)
+    def test_network_stats(self, *mocked):
+        """
+        Test network stats
+
+        """
+        plugin = System(config={'name': 'system'})
+        expected = {
+            'testhost.system.net_connections.active': 5,
+            'testhost.system.net_io_counters.bytes_sent': 1,
+            'testhost.system.net_io_counters.bytes_recv': 2,
+            'testhost.system.net_io_counters.packets_sent': 3,
+            'testhost.system.net_io_counters.packets_recv': 4,
+            'testhost.system.net_io_counters.errin': 5,
+            'testhost.system.net_io_counters.errout': 6,
+            'testhost.system.net_io_counters.dropin': 7,
+            'testhost.system.net_io_counters.dropout': 8
+        }
+        stats = plugin.get_network_stats()
+        for key, value in stats.iteritems():
+            self.assertTrue(key in expected)
+            self.assertEquals(value, expected[key])
+
+    @mock.patch('socket.gethostname', return_value='testhost')
+    @mock.patch('psutil.cpu_times_percent', side_effect=fake_cpu_times_percent)
+    @mock.patch('psutil.cpu_percent', return_value=100)
+    def test_cpu_stats(self, *mocked):
+        plugin = System(config={'name': 'system'})
+        expected = {
+            'testhost.system.cpu_times.percent.user': 1,
+            'testhost.system.cpu_times.percent.nice': 2,
+            'testhost.system.cpu_times.percent.system': 3,
+            'testhost.system.cpu_times.percent.idle': 4,
+            'testhost.system.cpu_times.percent.iowait': 5,
+            'testhost.system.cpu_times.percent.irq': 6,
+            'testhost.system.cpu_times.percent.softirq': 7,
+            'testhost.system.cpu_times.percent.steal': 8,
+            'testhost.system.cpu_times.percent.guest': 9,
+            'testhost.system.cpu_times.percent.guest_nice': 10,
+            'testhost.system.cpu.percent': 100
+        }
+        stats = plugin.get_cpu_stats()
+        for key, value in stats.iteritems():
+            self.assertTrue(key in expected)
+            self.assertEquals(value, expected[key])
+
+    @mock.patch('socket.gethostname', return_value='testhost')
+    @mock.patch('psutil.virtual_memory', side_effect=fake_virtual_memory)
+    @mock.patch('psutil.swap_memory', side_effect=fake_swap_memory)
+    def test_memory_stats(self, *mocked):
+        plugin = System(config={'name': 'system'})
+        expected = {
+            'testhost.system.virtual_memory.total': 1,
+            'testhost.system.virtual_memory.available': 2,
+            'testhost.system.virtual_memory.percent': 3,
+            'testhost.system.virtual_memory.used': 4,
+            'testhost.system.virtual_memory.free': 5,
+            'testhost.system.virtual_memory.active': 6,
+            'testhost.system.virtual_memory.inactive': 7,
+            'testhost.system.virtual_memory.buffers': 8,
+            'testhost.system.virtual_memory.cached': 9,
+            'testhost.system.swap_memory.total': 1,
+            'testhost.system.swap_memory.used': 2,
+            'testhost.system.swap_memory.free': 3,
+            'testhost.system.swap_memory.percent': 4,
+            'testhost.system.swap_memory.sin': 5,
+            'testhost.system.swap_memory.sout': 6
+        }
+        stats = plugin.get_memory_stats()
+        for key, value in stats.iteritems():
+            self.assertTrue(key in expected)
+            self.assertEquals(value, expected[key])
+
+    @mock.patch('socket.gethostname', return_value='testhost')
+    @mock.patch('psutil.disk_usage', side_effect=fake_disk_usage)
+    @mock.patch('psutil.disk_io_counters', side_effect=fake_disk_counters)
+    def test_disk_stats(self, *mocked):
+        plugin = System(config={'name': 'system'})
+        expected = {
+            'testhost.system.disk_usage./.total': 1,
+            'testhost.system.disk_usage./.used': 2,
+            'testhost.system.disk_usage./.free': 3,
+            'testhost.system.disk_usage./.percent': 4,
+            'testhost.system.disk_io_counters.read_count': 1,
+            'testhost.system.disk_io_counters.write_count': 2,
+            'testhost.system.disk_io_counters.read_bytes': 3,
+            'testhost.system.disk_io_counters.write_bytes': 4,
+            'testhost.system.disk_io_counters.read_time': 5,
+            'testhost.system.disk_io_counters.write_time': 6
+        }
+        stats = plugin.get_disk_stats()
+        for key, value in stats.iteritems():
+            self.assertTrue(key in expected)
+            self.assertEquals(value, expected[key])


### PR DESCRIPTION
Metric names are now '{prefix}.{host-id}.{agent name}.{suffix}'
